### PR TITLE
Update to Helm 3.16.3, kubectl 1.31.0, Alpine 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.21
 
 ARG VCS_REF
 ARG BUILD_DATE
@@ -12,13 +12,13 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
 
 # Note: Latest version of kubectl may be found at:
 # https://github.com/kubernetes/kubernetes/releases
-ENV KUBE_LATEST_VERSION="v1.18.3"
+ENV KUBE_LATEST_VERSION="v1.31.0"
 # Note: Latest version of helm may be found at
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v3.1.3"
+ENV HELM_VERSION="v3.16.3"
 
 RUN apk add --no-cache ca-certificates bash git openssh curl \
-    && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
+    && wget -q https://dl.k8s.io/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
     && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && chmod +x /usr/local/bin/helm \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 Supported tags and release links
 
+* [3.16.3](https://github.com/dtzar/helm-kubectl/releases/tag/3.16.3) - helm v3.16.3, kubectl v1.31.0, alpine 3.21
 * [3.2.4](https://github.com/dtzar/helm-kubectl/releases/tag/3.2.4) - helm v3.2.4, kubectl v1.18.3, alpine 3.12
 * [3.2.3](https://github.com/dtzar/helm-kubectl/releases/tag/3.2.3) - helm v3.2.3, kubectl v1.18.3, alpine 3.12
 * [3.2.1](https://github.com/dtzar/helm-kubectl/releases/tag/3.2.1) - helm v3.2.1, kubectl v1.18.2, alpine 3.11


### PR DESCRIPTION
## Summary
- Update Alpine base image from 3.11 to 3.21 (latest stable)
- Update Helm from v3.1.3 to v3.16.3 (latest stable)
- Update kubectl from v1.18.3 to v1.31.0 (latest stable)
- Fix kubectl download URL to use dl.k8s.io instead of deprecated Google storage URL
- Update README.md with new version information

## Test plan
- [x] Local Docker build completed successfully
- [x] Verified kubectl v1.31.0 and Helm v3.16.3 versions in container
- [x] Built and tagged Docker images: bscott/helm-kubectl:v3.16.3 and bscott/helm-kubectl:latest
- [x] Pushed images to Docker Hub
- [x] Created git tag 3.16.3

This brings the image up to date with the latest stable versions of all components, providing significant improvements in functionality and security.